### PR TITLE
build(renovate): change preset repository

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,6 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>ykzts/ykzts//renovate-config/default.json5'],
   kubernetes: {
-    fileMatch: ['^k8s/.+\\.yaml$'],
+    managerFilePatterns: ['^k8s/.+\\.yaml$'],
   },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['github>ykzts/ykzts//renovate-config/default.json5']
+  extends: ['github>ykzts/ykzts//renovate-config/default.json5'],
+  kubernetes: {
+    fileMatch: ['^k8s/.+\\.yaml$'],
+  },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,6 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>ykzts/ykzts//renovate-config/default.json5'],
   kubernetes: {
-    managerFilePatterns: ['^k8s/.+\\.yaml$'],
+    managerFilePatterns: ['/^k8s/.+\\.ya?ml$/'],
   },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['github>ykzts-technology/.github//renovate-config/default.json5']
+  extends: ['github>ykzts/ykzts//renovate-config/default.json5']
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to use a different shared config repository. The change ensures that the project now extends the Renovate config from the correct organization and repository.

* Configuration update:
  * [`.github/renovate.json5`](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790L3-R3): Changed the `extends` property to reference `ykzts/ykzts` instead of `ykzts-technology/.github`, ensuring the project uses the intended Renovate config.