### PR TITLE
feat(dns): add status

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -54,6 +54,12 @@ module "dns-public-zone" {
       type    = "HTTPS"
     },
     {
+      name    = "status"
+      records = ["uptime.stzky.com."]
+      ttl     = 3600
+      type    = "CNAME"
+    },
+    {
       name    = ""
       records = ["0 issue \"pki.goog\"", "0 issue \"sectigo.com\"", "0 issue \"letsencrypt.org\""]
       ttl     = 7200
@@ -65,25 +71,6 @@ module "dns-public-zone" {
       records = ["a0fb7df9f0"]
       ttl     = 3600
       type    = "TXT"
-    },
-    # SendGrid
-    {
-      name    = "em7827"
-      records = ["u26458027.wl028.sendgrid.net."]
-      ttl     = 3600
-      type    = "CNAME"
-    },
-    {
-      name    = "s1._domainkey"
-      records = ["s1.domainkey.u26458027.wl028.sendgrid.net."]
-      ttl     = 3600
-      type    = "CNAME"
-    },
-    {
-      name    = "s2._domainkey"
-      records = ["s2.domainkey.u26458027.wl028.sendgrid.net."]
-      ttl     = 3600
-      type    = "CNAME"
     },
     # Resend
     {


### PR DESCRIPTION
This pull request updates DNS records in the `dns.tf` file, primarily by removing old SendGrid-related CNAME records and adding a new CNAME record for a status subdomain. These changes help keep the DNS configuration up to date with current service usage.

DNS record updates:

* Added a new CNAME record for the `status` subdomain pointing to `uptime.stzky.com.` to support status monitoring.

Decommissioning unused email service records:

* Removed three SendGrid-related CNAME records (`em7827`, `s1._domainkey`, and `s2._domainkey`) that are no longer needed, simplifying the DNS zone and reflecting the transition away from SendGrid.Added a new CNAME record for 'status' and removed SendGrid records.